### PR TITLE
Reset session inactivity time on requests to hub

### DIFF
--- a/hub-extensions/extension-proxy/src/main/java/io/sterodium/extensions/hub/proxy/HubRequestsProxyingServlet.java
+++ b/hub-extensions/extension-proxy/src/main/java/io/sterodium/extensions/hub/proxy/HubRequestsProxyingServlet.java
@@ -78,7 +78,11 @@ public class HubRequestsProxyingServlet extends RegistryBasedServlet {
         LOGGER.info("Forwarding request with path: " + path);
         String sessionId = SeleniumSessions.getSessionIdFromPath(path);
         LOGGER.info("Retrieving remote host for session: " + sessionId);
-        URL remoteHost = new SeleniumSessions(getRegistry()).getRemoteHostForSession(sessionId);
+
+        SeleniumSessions sessions = new SeleniumSessions(getRegistry());
+        sessions.refreshTimeout(sessionId);
+
+        URL remoteHost = sessions.getRemoteHostForSession(sessionId);
         String host = remoteHost.getHost();
         int port = remoteHost.getPort();
         LOGGER.info("Remote host retrieved: " + host + ":" + port);

--- a/hub-extensions/extension-proxy/src/main/java/io/sterodium/extensions/hub/proxy/session/SeleniumSessions.java
+++ b/hub-extensions/extension-proxy/src/main/java/io/sterodium/extensions/hub/proxy/session/SeleniumSessions.java
@@ -30,6 +30,20 @@ public class SeleniumSessions {
         throw new IllegalArgumentException("Invalid sessionId. No active session is present for id:" + sessionId);
     }
 
+    public void refreshTimeout(String sessionId) {
+        for (TestSession activeSession : registry.getActiveSessions()) {
+            if (sessionId.equals(activeSession.getExternalKey().getKey())) {
+                refreshTimeout(activeSession);
+            }
+        }
+    }
+
+    private void refreshTimeout(TestSession activeSession) {
+        if (activeSession.getInactivityTime() != 0) {
+            activeSession.setIgnoreTimeout(false);
+        }
+    }
+
     public static String getSessionIdFromPath(String pathInfo) {
         Matcher matcher = SESSION_ID_PATTERN.matcher(pathInfo);
         if (matcher.matches()) {

--- a/hub-extensions/extension-proxy/src/test/java/io/sterodium/extensions/hub/proxy/session/SeleniumSessionsTest.java
+++ b/hub-extensions/extension-proxy/src/test/java/io/sterodium/extensions/hub/proxy/session/SeleniumSessionsTest.java
@@ -1,14 +1,46 @@
 package io.sterodium.extensions.hub.proxy.session;
 
+import com.google.common.collect.Sets;
+import org.junit.Before;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+import org.openqa.grid.internal.DefaultTimeSource;
+import org.openqa.grid.internal.ExternalSessionKey;
+import org.openqa.grid.internal.Registry;
+import org.openqa.grid.internal.TestSession;
 
+import static junit.framework.TestCase.assertTrue;
 import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.when;
 
 /**
  * @author Alexey Nikolaenko alexey@tcherezov.com
  *         Date: 22/09/2015
  */
+@RunWith(MockitoJUnitRunner.class)
 public class SeleniumSessionsTest {
+
+    @Mock
+    Registry registry;
+    @Mock
+    ExternalSessionKey externalSessionKey;
+
+    TestSession activeSession;
+
+    SeleniumSessions seleniumSessions;
+
+    @Before
+    public void setUp() {
+        seleniumSessions = new SeleniumSessions(registry);
+        activeSession = spy(new TestSession(null, null, new DefaultTimeSource()));
+
+        when(activeSession.getExternalKey()).thenReturn(externalSessionKey);
+        when(externalSessionKey.getKey()).thenReturn("sessionId");
+        when(registry.getActiveSessions()).thenReturn(Sets.newHashSet(activeSession));
+    }
 
     @Test(expected = IllegalArgumentException.class)
     public void getSessionIdExceptional() {
@@ -32,4 +64,33 @@ public class SeleniumSessionsTest {
         assertEquals("/request", SeleniumSessions.trimSessionPath("/session/id/request"));
         assertEquals("/another/one", SeleniumSessions.trimSessionPath("/session/id/another/one"));
     }
+
+    @Test
+    public void shouldRefreshTimeout() throws InterruptedException {
+        long inactivityTime = activeSession.getInactivityTime();
+
+        Thread.sleep(100);
+
+        seleniumSessions.refreshTimeout("sessionId");
+
+        long inactivityTimeAfterRefresh = activeSession.getInactivityTime();
+
+        assertTrue("Inactivity time should be less after refresh", inactivityTime > inactivityTimeAfterRefresh);
+    }
+
+    @Test
+    public void shouldNotRefreshTimeoutIfTimeoutIsIgnored() {
+        activeSession.setIgnoreTimeout(true);
+
+        long inactivityTime = activeSession.getInactivityTime();
+
+        seleniumSessions.refreshTimeout("sessionId");
+
+        long inactivityTimeAfterRefresh = activeSession.getInactivityTime();
+
+        assertTrue(inactivityTime == 0);
+        assertTrue("Inactivity time should be 0 when timeout is ignored", inactivityTime == inactivityTimeAfterRefresh);
+    }
+
+
 }


### PR DESCRIPTION
- session should not timeout if long operations on extensions happen
