### PR TITLE
Redirect logging to log4j

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,9 @@
 # virtual machine crash logs, see http://www.java.com/en/download/help/error_hotspot.xml
 hs_err_pid*
 target
+
+# IntelliJ
+.idea/
+*.iml
+*.iws
+

--- a/grid-starter/pom.xml
+++ b/grid-starter/pom.xml
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>selenium-grid-extensions</artifactId>
+        <groupId>io.sterodium</groupId>
+        <version>0.6-SNAPSHOT</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>grid-starter</artifactId>
+    <name>Grid Starter</name>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.seleniumhq.selenium</groupId>
+            <artifactId>selenium-server</artifactId>
+            <version>2.47.1</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>jul-to-slf4j</artifactId>
+            <version>1.7.12</version>
+        </dependency>
+
+        <!--Test-->
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-shade-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>shade</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/grid-starter/src/main/java/io/sterodium/extensions/GridStarter.java
+++ b/grid-starter/src/main/java/io/sterodium/extensions/GridStarter.java
@@ -1,0 +1,49 @@
+package io.sterodium.extensions;
+
+import io.sterodium.extensions.spi.GridConfigurator;
+import org.openqa.grid.selenium.GridLauncher;
+import org.slf4j.bridge.SLF4JBridgeHandler;
+
+import java.util.ServiceLoader;
+
+/**
+ * Installs JUL to SLF4J logging bridge and configures command line arguments before launching Selenium Grid server.
+ *
+ * @author Vladimir Ilyin ilyin371@gmail.com
+ *         Date: 20/11/2015
+ */
+public final class GridStarter {
+
+    private String[] args;
+
+    private GridStarter(String[] args) {
+        this.args = args;
+    }
+
+    public static void main(String[] args) throws Exception {
+        bridgeJulToSlf4j();
+
+        GridStarter starter = new GridStarter(args);
+        starter.configure();
+        starter.start();
+    }
+
+    private void configure() {
+        ServiceLoader<GridConfigurator> services = ServiceLoader.load(GridConfigurator.class);
+        for (GridConfigurator gridConfigurator : services) {
+            args = gridConfigurator.configure(args);
+        }
+    }
+
+    static void bridgeJulToSlf4j() {
+        if (!SLF4JBridgeHandler.isInstalled()) {
+            SLF4JBridgeHandler.removeHandlersForRootLogger();
+            SLF4JBridgeHandler.install();
+        }
+    }
+
+    private void start() throws Exception {
+        GridLauncher.main(args);
+    }
+
+}

--- a/grid-starter/src/main/java/io/sterodium/extensions/common/CommandLineOptionManager.java
+++ b/grid-starter/src/main/java/io/sterodium/extensions/common/CommandLineOptionManager.java
@@ -1,0 +1,62 @@
+package io.sterodium.extensions.common;
+
+import org.openqa.grid.common.CommandLineOptionHelper;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Iterator;
+
+/**
+* @author Vladimir Ilyin ilyin371@gmail.com
+*         Date: 20/11/2015
+*/
+public class CommandLineOptionManager {
+
+    private CommandLineOptionHelper helper;
+    private String[] args;
+
+    public CommandLineOptionManager(String[] args) {
+        setArgs(args);
+    }
+
+    public void removeParam(String name) {
+        ArrayList<String> params = new ArrayList<>();
+        Collections.addAll(params, getAllParams());
+
+        for (Iterator<String> iterator = params.iterator(); iterator.hasNext(); ) {
+            String param = iterator.next();
+            if (name.equals(param)) {
+                removeParamWithValue(iterator);
+            }
+        }
+        setArgs(params.toArray(new String[params.size()]));
+    }
+
+    private static void removeParamWithValue(Iterator<String> iterator) {
+        iterator.remove();
+        if (iterator.hasNext()) {
+            String value = iterator.next();
+            if (!value.startsWith("-")) {
+                iterator.remove();
+            }
+        }
+    }
+
+    public boolean isParamPresent(String name) {
+        return helper.isParamPresent(name);
+    }
+
+    public String getParamValue(String name) {
+        return helper.getParamValue(name);
+    }
+
+    public String[] getAllParams() {
+        return args;
+    }
+
+    private void setArgs(String[] args) {
+        this.args = args;
+        helper = new CommandLineOptionHelper(args);
+    }
+
+}

--- a/grid-starter/src/main/java/io/sterodium/extensions/spi/GridConfigurator.java
+++ b/grid-starter/src/main/java/io/sterodium/extensions/spi/GridConfigurator.java
@@ -1,0 +1,14 @@
+package io.sterodium.extensions.spi;
+
+/**
+ * @author Vladimir Ilyin ilyin371@gmail.com
+ *         Date: 20/11/2015
+ */
+public interface GridConfigurator {
+    /**
+     * Updates command line arguments
+     * @param args
+     * @return updated arguments
+     */
+    String[] configure(String[] args);
+}

--- a/grid-starter/src/test/java/io/sterodium/extensions/GridStarterTest.java
+++ b/grid-starter/src/test/java/io/sterodium/extensions/GridStarterTest.java
@@ -1,0 +1,17 @@
+package io.sterodium.extensions;
+
+import org.junit.Test;
+import org.slf4j.bridge.SLF4JBridgeHandler;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class GridStarterTest {
+
+    @Test
+    public void shouldInstallSLF4JBridge() throws Exception {
+        assertFalse(SLF4JBridgeHandler.isInstalled());
+        GridStarter.bridgeJulToSlf4j();
+        assertTrue(SLF4JBridgeHandler.isInstalled());
+    }
+}

--- a/grid-starter/src/test/java/io/sterodium/extensions/common/CommandLineOptionManagerTest.java
+++ b/grid-starter/src/test/java/io/sterodium/extensions/common/CommandLineOptionManagerTest.java
@@ -1,0 +1,59 @@
+package io.sterodium.extensions.common;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Iterator;
+
+import static org.junit.Assert.assertEquals;
+
+@RunWith(Parameterized.class)
+public class CommandLineOptionManagerTest {
+
+    private CommandLineOptionManager manager;
+    private String paramName;
+    private String expected;
+    private String message;
+
+    public CommandLineOptionManagerTest(String args, String paramName, String expected, String message) {
+        manager = new CommandLineOptionManager(args.split(" "));
+        this.paramName = paramName;
+        this.expected = expected;
+        this.message = message;
+    }
+
+    @Parameterized.Parameters(name = "{index}: {3}")
+    public static Collection<Object[]> data() {
+        return Arrays.asList(new Object[][] {
+                { "-p1 v1", "-p1", "", "Should remove named param and value"},
+                { "-p1 v1 -p1 v1", "-p1", "", "Should remove duplicated"},
+                { "-p0 v0 -p1 v1 -p2 v2", "-p1", "-p0 v0 -p2 v2", "Should leave other params intact"},
+                { "-p1 v1", "-x1", "-p1 v1", "Should do nothing if named param not found"},
+                { "", "-x1", "", "Should do nothing if param list is empty"},
+                { "-p1 -p2 v2", "-p1", "-p2 v2", "Should remove key if value is missing"},
+                { "-p1", "-p1", "", "Should remove key if value is missing"}
+        });
+    }
+
+    @Test
+    public void testRemoveParam() throws Exception {
+        manager.removeParam(paramName);
+        String actual = joinStrings(manager.getAllParams(), " ");
+        assertEquals(message, expected, actual);
+    }
+
+    private static String joinStrings(String[] strings, String separator){
+        Iterator<String> iter = Arrays.asList(strings).iterator();
+        StringBuilder sb = new StringBuilder();
+        if (iter.hasNext()) {
+            sb.append(iter.next());
+            while (iter.hasNext()) {
+                sb.append(separator).append(iter.next());
+            }
+        }
+        return sb.toString();
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -80,8 +80,9 @@
         <module>hub-extensions</module>
         <module>node-extensions</module>
         <module>extension-clients</module>
+        <module>grid-starter</module>
+        <module>selenium-log4j</module>
     </modules>
-
     <properties>
 
         <!--project-->

--- a/selenium-log4j/pom.xml
+++ b/selenium-log4j/pom.xml
@@ -1,0 +1,77 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>selenium-grid-extensions</artifactId>
+        <groupId>io.sterodium</groupId>
+        <version>0.6-SNAPSHOT</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>selenium-log4j</artifactId>
+    <name>Selenium log4j</name>
+
+    <properties>
+        <slf4j.version>1.7.12</slf4j.version>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.sterodium</groupId>
+            <artifactId>grid-starter</artifactId>
+            <version>0.6-SNAPSHOT</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.seleniumhq.selenium</groupId>
+            <artifactId>selenium-server</artifactId>
+            <version>2.47.1</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+            <version>${slf4j.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-log4j12</artifactId>
+            <version>${slf4j.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>log4j</groupId>
+            <artifactId>log4j</artifactId>
+            <version>1.2.17</version>
+        </dependency>
+
+        <!--Test-->
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.hamcrest</groupId>
+            <artifactId>hamcrest-all</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-shade-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>shade</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/selenium-log4j/src/main/java/io/sterodium/extensions/log/LoggingConfigurator.java
+++ b/selenium-log4j/src/main/java/io/sterodium/extensions/log/LoggingConfigurator.java
@@ -1,0 +1,121 @@
+package io.sterodium.extensions.log;
+
+import io.sterodium.extensions.common.CommandLineOptionManager;
+import io.sterodium.extensions.spi.GridConfigurator;
+import org.apache.log4j.ConsoleAppender;
+import org.apache.log4j.Level;
+import org.apache.log4j.Logger;
+import org.apache.log4j.PatternLayout;
+import org.apache.log4j.RollingFileAppender;
+import org.slf4j.LoggerFactory;
+
+import java.io.File;
+
+/**
+ * Configures log output and log level from command line arguments if logging is not configured by
+ * log4j.properties. If no log file is specified then logs to console.
+ *
+ * -log {file_path}  sets log file
+ * -debug            sets log level to DEBUG (default is INFO)
+ *
+ * @author Vladimir Ilyin ilyin371@gmail.com
+ *         Date: 20/11/2015
+ */
+public class LoggingConfigurator implements GridConfigurator {
+
+    private static final org.slf4j.Logger LOG = LoggerFactory.getLogger(LoggingConfigurator.class);
+
+    private static final String LOG_FILE_PARAM = "-log";
+    private static final String LOG_FILE_PROPERTY = "selenium.LOGGER";
+    private static final String LOG_LEVEL_PROPERTY = "selenium.LOGGER.level";
+
+    private static final String PATTERN = "%d{ISO8601} [%t] [%p] [%c] %m%n";
+    private static final String MAX_FILE_SIZE = "10MB";
+    private static final int MAX_BACKUPS = 1;
+
+    private CommandLineOptionManager commandLineOptionManager;
+    private Level logLevel;
+
+    @Override
+    public String[] configure(String[] args) {
+        commandLineOptionManager = new CommandLineOptionManager(args);
+
+        boolean isLog4jConfigured = Logger.getRootLogger().getAllAppenders().hasMoreElements();
+        if (!isLog4jConfigured) {
+            logLevel = commandLineOptionManager.isParamPresent("-debug")
+                    ? Level.DEBUG
+                    : getDefaultLogLevel();
+
+            String logFilename = getLogFilename();
+            if (logFilename != null && !logFilename.isEmpty()) {
+                installFileAppender(logFilename);
+            } else {
+                installConsoleAppender();
+                LOG.info("No logging configuration found, logging to console");
+            }
+        }
+        clearLogFilenameParam();
+        return commandLineOptionManager.getAllParams();
+    }
+
+
+    private void installConsoleAppender() {
+        ConsoleAppender console = new ConsoleAppender();
+        console.setName("Console");
+        console.setThreshold(logLevel);
+        console.setLayout(new PatternLayout(PATTERN));
+        console.setFollow(true);
+        console.activateOptions();
+
+        Logger.getRootLogger().addAppender(console);
+    }
+
+    private void installFileAppender(String logFilename) {
+        RollingFileAppender file = new RollingFileAppender();
+        file.setName("FileAppender");
+        file.setThreshold(logLevel);
+        file.setFile(new File(logFilename).getAbsolutePath());
+        file.setMaxFileSize(MAX_FILE_SIZE);
+        file.setMaxBackupIndex(MAX_BACKUPS);
+        file.setLayout(new PatternLayout(PATTERN));
+        file.setAppend(true);
+        file.activateOptions();
+
+        Logger.getRootLogger().addAppender(file);
+    }
+
+    private String getLogFilename() {
+        String logFilename;
+        if (commandLineOptionManager.isParamPresent(LOG_FILE_PARAM)) {
+            logFilename = commandLineOptionManager.getParamValue(LOG_FILE_PARAM);
+        } else {
+            logFilename = getLogFilenameFromSystemProperty();
+        }
+        return logFilename;
+    }
+
+    private void clearLogFilenameParam() {
+        commandLineOptionManager.removeParam(LOG_FILE_PARAM);
+        System.clearProperty(LOG_FILE_PROPERTY);
+    }
+
+    private static String getLogFilenameFromSystemProperty() {
+        final String logFilename;
+
+        logFilename = System.getProperty(LOG_FILE_PROPERTY);
+        if (null == logFilename) {
+            return null;
+        } else {
+            return new File(logFilename).getAbsolutePath();
+        }
+    }
+
+    private static Level getDefaultLogLevel() {
+        final String logLevelProperty = System.getProperty(LOG_LEVEL_PROPERTY);
+        if (null == logLevelProperty) {
+            return Level.INFO;
+        } else {
+            return Level.toLevel(logLevelProperty);
+        }
+    }
+}

--- a/selenium-log4j/src/main/resources/META-INF/services/io.sterodium.extensions.spi.GridConfigurator
+++ b/selenium-log4j/src/main/resources/META-INF/services/io.sterodium.extensions.spi.GridConfigurator
@@ -1,0 +1,1 @@
+io.sterodium.extensions.log.LoggingConfigurator

--- a/selenium-log4j/src/test/java/io/sterodium/extensions/log/LoggingConfiguratorTest.java
+++ b/selenium-log4j/src/test/java/io/sterodium/extensions/log/LoggingConfiguratorTest.java
@@ -1,0 +1,75 @@
+package io.sterodium.extensions.log;
+
+import org.apache.log4j.Appender;
+import org.apache.log4j.ConsoleAppender;
+import org.apache.log4j.Logger;
+import org.apache.log4j.RollingFileAppender;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.slf4j.bridge.SLF4JBridgeHandler;
+
+import java.util.Enumeration;
+import java.util.LinkedList;
+import java.util.List;
+
+import static org.hamcrest.CoreMatchers.endsWith;
+import static org.hamcrest.CoreMatchers.instanceOf;
+import static org.hamcrest.core.Is.is;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertThat;
+
+
+public class LoggingConfiguratorTest {
+
+    private static final String LOG_FILENAME = "selenium.log";
+    private static final String[] NO_ARGS = new String[0];
+    private List<Appender> appenders;
+    private LoggingConfigurator loggingConfigurator;
+
+    @Before
+    public void setUp() throws Exception {
+        loggingConfigurator = new LoggingConfigurator();
+        appenders = new LinkedList<>();
+        Enumeration e = Logger.getRootLogger().getAllAppenders();
+        while (e.hasMoreElements()) {
+            Object appender = e.nextElement();
+            if (appender instanceof Appender) {
+                appenders.add((Appender) appender);
+            }
+        }
+    }
+
+    @Test
+    public void configure_shouldInstallConsoleAppender() throws Exception {
+        loggingConfigurator.configure(NO_ARGS);
+
+        Appender appender = Logger.getRootLogger().getAppender("Console");
+        assertNotNull(appender);
+        assertThat(appender, instanceOf(ConsoleAppender.class));
+    }
+
+    @Test
+    public void configure_shouldInstallFileAppenderFromArguments() throws Exception {
+
+        String[] arguments = loggingConfigurator.configure(new String[]{"-log", "target/" + LOG_FILENAME});
+
+        Appender appender = Logger.getRootLogger().getAppender("FileAppender");
+        assertNotNull(appender);
+        assertThat(appender, instanceOf(RollingFileAppender.class));
+        assertThat(((RollingFileAppender) appender).getFile(), endsWith(LOG_FILENAME));
+        assertThat(arguments.length, is(0));
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        // restore
+        Logger.getRootLogger().removeAllAppenders();
+        for (Appender appender : appenders) {
+            Logger.getRootLogger().addAppender(appender);
+        }
+
+        SLF4JBridgeHandler.uninstall();
+    }
+
+}


### PR DESCRIPTION
- redirect JUL to log4j through SLF4J bridge
- support of -log command line arg with log file size limit = 10MB
- log to console if no log4j.properties provided
- added a wrapper over stock GridLauncher
