### PR TITLE
Update to RMI protocol extension 0.3

### DIFF
--- a/node-extensions/sikuli-extension/src/main/java/io/sterodium/extensions/node/SikuliExtensionServlet.java
+++ b/node-extensions/sikuli-extension/src/main/java/io/sterodium/extensions/node/SikuliExtensionServlet.java
@@ -4,8 +4,6 @@ import com.google.gson.Gson;
 import io.sterodium.extensions.node.rmi.SikuliApplication;
 import io.sterodium.rmi.protocol.MethodInvocationDto;
 import io.sterodium.rmi.protocol.MethodInvocationResultDto;
-import io.sterodium.rmi.protocol.server.RemoteMethodInvocationException;
-import org.apache.http.HttpStatus;
 import org.openqa.grid.internal.Registry;
 import org.openqa.grid.web.servlet.RegistryBasedServlet;
 
@@ -41,16 +39,9 @@ public class SikuliExtensionServlet extends RegistryBasedServlet {
             resp.sendError(HttpServletResponse.SC_BAD_REQUEST, "Can't find object ID in URL string");
             return;
         }
-
         MethodInvocationDto method = GSON.fromJson(req.getReader(), MethodInvocationDto.class);
-
-        try {
-            MethodInvocationResultDto result = SIKULI_APPLICATION.invoke(objectId, method);
-            resp.getWriter().write(GSON.toJson(result));
-        } catch (RemoteMethodInvocationException e) {
-            resp.setStatus(HttpStatus.SC_BAD_REQUEST);
-            resp.getWriter().write(e.getMessage());
-        }
+        MethodInvocationResultDto result = SIKULI_APPLICATION.invoke(objectId, method);
+        resp.getWriter().write(GSON.toJson(result));
     }
 
     private String getObjectId(HttpServletRequest req) {

--- a/node-extensions/sikuli-extension/src/test/java/io/sterodium/extensions/node/SikuliExtensionServletTest.java
+++ b/node-extensions/sikuli-extension/src/test/java/io/sterodium/extensions/node/SikuliExtensionServletTest.java
@@ -74,7 +74,7 @@ public class SikuliExtensionServletTest {
 
         int statusCode = httpResponse.getStatusLine().getStatusCode();
 
-        assertThat(statusCode, is(HttpStatus.SC_BAD_REQUEST));
+        assertThat(statusCode, is(HttpStatus.SC_OK));
         assertThat(EntityUtils.toString(httpResponse.getEntity()), containsString("notExistingMethod not found"));
     }
 

--- a/pom.xml
+++ b/pom.xml
@@ -224,7 +224,7 @@
             <dependency>
                 <groupId>io.sterodium</groupId>
                 <artifactId>sterodium-rmi</artifactId>
-                <version>0.2</version>
+                <version>0.3</version>
             </dependency>
 
             <!--Extension Clients-->


### PR DESCRIPTION
- find RMI error information in JSON instead of HTTP error response code
