### PR TITLE
Fixing checkStyle build fail error by using one liner return statement , Updating README.md file , Fixing old failing testcase because of MIME issue

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,6 +153,13 @@ FileExtensionClient fileExtensionClient = new FileExtensionClient(host, port, se
 File fileFromNode = fileExtensionClient.download(pathToFile);
 ```
 
+File deletion from selenium node: (which can be used as cleanup after upload/download activity performed on node)
+
+```java
+FileExtensionClient fileExtensionClient = new FileExtensionClient(host, port, sessionId);
+boolean isFiledeleted = fileExtensionClient.delete(pathToFile);
+```
+
 ## Build
 
 ```

--- a/extension-clients/file-extension-client/src/main/java/io/sterodium/extensions/client/delete/FileDeleteRequest.java
+++ b/extension-clients/file-extension-client/src/main/java/io/sterodium/extensions/client/delete/FileDeleteRequest.java
@@ -47,11 +47,7 @@ public class FileDeleteRequest {
             CloseableHttpClient httpClient = HttpClients.createDefault();
             CloseableHttpResponse execute = httpClient.execute(httpHost, request);
             int statusCode = execute.getStatusLine().getStatusCode();
-            if (HttpStatus.SC_OK == statusCode) {
-                return true;
-            } else {
-                return false;
-            }
+            return HttpStatus.SC_OK == statusCode;
         } catch (IOException e) {
             return false;
         }

--- a/hub-extensions/extension-proxy/src/test/java/io/sterodium/extensions/hub/proxy/HubRequestsProxyingServletTest.java
+++ b/hub-extensions/extension-proxy/src/test/java/io/sterodium/extensions/hub/proxy/HubRequestsProxyingServletTest.java
@@ -119,6 +119,7 @@ public class HubRequestsProxyingServletTest {
         HttpPost httpPost = new HttpPost(String.format("http://localhost:%d/%s/session/%s/%s/proper/get/path/params", hubPort,
                 HubRequestsProxyingServlet.class.getSimpleName(), "session_id",
                 "stubbyExtension"));
+        setEntityWithExpectedContent(httpPost);
         httpClient.execute(httpPost);
 
         verify(mockedFunction, times(1)).apply(any(HttpServletRequest.class), any(HttpServletResponse.class));
@@ -215,6 +216,7 @@ public class HubRequestsProxyingServletTest {
         HttpPost httpPost = new HttpPost(String.format("http://localhost:%d/%s/session/%s/%s/proper/get/path/params", hubPort,
                 HubRequestsProxyingServlet.class.getSimpleName(), "session_id",
                 "stubbyExtension"));
+        setEntityWithExpectedContent(httpPost);
         CloseableHttpResponse httpResponse = httpClient.execute(httpPost);
 
         verify(mockedFunction, times(1)).apply(any(HttpServletRequest.class), any(HttpServletResponse.class));


### PR DESCRIPTION
PR [54](https://github.com/sterodium/selenium-grid-extensions/pull/54) causes checkStyle failures . This PR fixes it