### PR TITLE
Fix to handle invalid char in MIME type

### DIFF
--- a/extension-clients/file-extension-client/src/main/java/io/sterodium/extensions/client/upload/ResourceUploadRequest.java
+++ b/extension-clients/file-extension-client/src/main/java/io/sterodium/extensions/client/upload/ResourceUploadRequest.java
@@ -1,6 +1,8 @@
 package io.sterodium.extensions.client.upload;
 
 import com.google.common.base.Throwables;
+
+import org.apache.http.Consts;
 import org.apache.http.HttpHost;
 import org.apache.http.HttpStatus;
 import org.apache.http.client.methods.CloseableHttpResponse;
@@ -8,6 +10,7 @@ import org.apache.http.client.methods.HttpPost;
 import org.apache.http.entity.InputStreamEntity;
 import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.http.impl.client.HttpClients;
+import org.apache.http.protocol.HTTP;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.zeroturnaround.zip.commons.IOUtils;
@@ -44,13 +47,12 @@ public class ResourceUploadRequest {
         CloseableHttpClient httpClient = HttpClients.createDefault();
 
         HttpPost request = new HttpPost(String.format(FILE_UPLOAD_EXTENSION_PATH, sessionId));
-        request.setHeader("Content-Type", "application/octet-stream");
-
+        request.setHeader(HTTP.CONTENT_TYPE, "application/octet-stream");
+        request.setHeader(HTTP.CONTENT_ENCODING, Consts.ISO_8859_1.name());
         try {
             FileInputStream fileInputStream = new FileInputStream(zip);
             InputStreamEntity entity = new InputStreamEntity(fileInputStream);
             request.setEntity(entity);
-
             CloseableHttpResponse execute = httpClient.execute(httpHost, request);
 
             int statusCode = execute.getStatusLine().getStatusCode();

--- a/hub-extensions/extension-proxy/src/main/java/io/sterodium/extensions/hub/proxy/client/RequestForwardingClient.java
+++ b/hub-extensions/extension-proxy/src/main/java/io/sterodium/extensions/hub/proxy/client/RequestForwardingClient.java
@@ -1,6 +1,7 @@
 package io.sterodium.extensions.hub.proxy.client;
 
 import io.sterodium.extensions.hub.proxy.session.SeleniumSessions;
+
 import org.apache.http.client.methods.CloseableHttpResponse;
 import org.apache.http.client.methods.HttpDelete;
 import org.apache.http.client.methods.HttpGet;
@@ -72,7 +73,9 @@ public class RequestForwardingClient {
         HttpPost httpPost = new HttpPost();
         InputStreamEntity entity = new InputStreamEntity(request.getInputStream(),
                 request.getContentLength(),
-                ContentType.create(request.getContentType()));
+                // some requests contain ContentType;Encoding and fails in validation.
+                // So striping Encoding and retaining only ContentType
+                ContentType.create((request.getContentType().split(";")[0])));
         httpPost.setEntity(entity);
 
         return httpPost;


### PR DESCRIPTION
With new selenium grid when a request received we see mime with encoding. (ex:- plaintext; UTF-8) This addition of encoding is breaking the code. Here is the function that is causing issue. To handle I am stripping encoding if present
```
    private static boolean valid(final String s) {
        for (int i = 0; i < s.length(); i++) {
            final char ch = s.charAt(i);
            if (ch == '"' || ch == ',' || ch == ';') {
                return false;
            }
        }
        return true;
    }
```

@echoAlexey can you please merge above changes too?

This is caused because we use classes from org.apache.httpcomponents.httpcore

Special char check with httpcore -4.4.6
```
    public static ContentType create(final String mimeType, final Charset charset) {
        final String normalizedMimeType = Args.notBlank(mimeType, "MIME type").toLowerCase(Locale.ROOT);
        Args.check(valid(normalizedMimeType), "MIME type may not contain reserved characters");
        return new ContentType(normalizedMimeType, charset);
    }
```
Special char check not present with httpcore-4.4.5
```
 ContentType(
            final String mimeType,
            final Charset charset) {
        this.mimeType = mimeType;
        this.charset = charset;
        this.params = null;
    }
```
 httpcore -4.4.6 implicitly  coming from selenium-server dependency. Now recent selenium-server comes with new httpcore-4.4.6 and  that checks for specialchars. This check was not present in httpcore < 4.4.5 and introduced in 4.4.6. To get away with i am striping off the  encoding part. If I hardcode the dependency to 4.4.5 when our servlet is running under seleniumgrid it picks 4.4.6 as selenium grid dependencies override this dependency. So stripping off the encoding in contentTYpe is the right fix at the moment.