### PR TITLE
Solving SeleniumSessions.refreshTimeout() method throwing NPE & Adding overloaded download method to download file with specific extension

### DIFF
--- a/extension-clients/file-extension-client/src/main/java/io/sterodium/extensions/client/FileExtensionClient.java
+++ b/extension-clients/file-extension-client/src/main/java/io/sterodium/extensions/client/FileExtensionClient.java
@@ -40,6 +40,16 @@ public class FileExtensionClient {
     }
 
     /**
+     * Download file from Selenium Node.
+     *
+     * @param pathToFile absolute path to file
+     * @return downloaded file with extension in temp directory
+     */
+    public File download(String pathToFile, String extension) {
+        return fileDownloadRequest.download(pathToFile, extension);
+    }
+
+    /**
      * Upload resource folder from classpath.
      *
      * @param resourcesPath path to resource folder in classpath

--- a/hub-extensions/extension-proxy/src/main/java/io/sterodium/extensions/hub/proxy/session/SeleniumSessions.java
+++ b/hub-extensions/extension-proxy/src/main/java/io/sterodium/extensions/hub/proxy/session/SeleniumSessions.java
@@ -32,8 +32,10 @@ public class SeleniumSessions {
 
     public void refreshTimeout(String sessionId) {
         for (TestSession activeSession : registry.getActiveSessions()) {
-            if (sessionId.equals(activeSession.getExternalKey().getKey())) {
-                refreshTimeout(activeSession);
+            if ((activeSession != null) && (sessionId != null) && (activeSession.getExternalKey() != null)) {
+                if (sessionId.equals(activeSession.getExternalKey().getKey())) {
+                    refreshTimeout(activeSession);
+                }
             }
         }
     }


### PR DESCRIPTION
This PR contains 2 changes (1 improvement and 1 bug fix )

Improvement 
I have added overloaded download method , which takes an extra param (String extension) . This will allow file to be downloaded in specific extension . So instead of default file extension (which right now is '.tmp' , it gives user flexibility to download file in specific extension)

Bug fix 
https://github.com/sterodium/selenium-grid-extensions/issues/63
