### PR TITLE
#68 fix: Base64URL coding to work with files with spaces in name

### DIFF
--- a/extension-clients/file-extension-client/src/main/java/io/sterodium/extensions/client/delete/FileDeleteRequest.java
+++ b/extension-clients/file-extension-client/src/main/java/io/sterodium/extensions/client/delete/FileDeleteRequest.java
@@ -1,8 +1,8 @@
 package io.sterodium.extensions.client.delete;
 
 import java.io.IOException;
-import java.io.UnsupportedEncodingException;
-import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
 
 import org.apache.http.HttpHost;
 import org.apache.http.HttpStatus;
@@ -35,12 +35,7 @@ public class FileDeleteRequest {
 
     public boolean delete(String pathToFile) {
         String encodedPath;
-        try {
-            encodedPath = URLEncoder.encode(pathToFile, "UTF-8");
-        } catch (UnsupportedEncodingException e) {
-            LOGGER.error("Failed to encode path", e);
-            return false;
-        }
+        encodedPath = Base64.getUrlEncoder().encodeToString(pathToFile.getBytes(StandardCharsets.UTF_8));
 
         HttpGet request = new HttpGet(String.format(FILE_DELETE_EXTENSION_PATH, sessionId, encodedPath));
         try {

--- a/extension-clients/file-extension-client/src/main/java/io/sterodium/extensions/client/download/FileDownloadRequest.java
+++ b/extension-clients/file-extension-client/src/main/java/io/sterodium/extensions/client/download/FileDownloadRequest.java
@@ -14,8 +14,8 @@ import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
-import java.io.UnsupportedEncodingException;
-import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
 
 /**
  * @author Alexey Nikolaenko alexey@tcherezov.com
@@ -37,12 +37,7 @@ public class FileDownloadRequest {
 
     public File download(String pathToFile, String extension) {
         String encodedPath;
-        try {
-            encodedPath = URLEncoder.encode(pathToFile, "UTF-8");
-        } catch (UnsupportedEncodingException e) {
-            LOGGER.error("Failed to encode path", e);
-            return null;
-        }
+        encodedPath = Base64.getUrlEncoder().encodeToString(pathToFile.getBytes(StandardCharsets.UTF_8));
 
         HttpGet request = new HttpGet(String.format(FILE_DOWNLOAD_EXTENSION_PATH, sessionId, encodedPath));
         try {
@@ -68,12 +63,7 @@ public class FileDownloadRequest {
 
     public File download(String pathToFile) {
         String encodedPath;
-        try {
-            encodedPath = URLEncoder.encode(pathToFile, "UTF-8");
-        } catch (UnsupportedEncodingException e) {
-            LOGGER.error("Failed to encode path", e);
-            return null;
-        }
+        encodedPath = Base64.getUrlEncoder().encodeToString(pathToFile.getBytes(StandardCharsets.UTF_8));
 
         HttpGet request = new HttpGet(String.format(FILE_DOWNLOAD_EXTENSION_PATH, sessionId, encodedPath));
         try {

--- a/extension-clients/file-extension-client/src/test/java/io/sterodium/extensions/client/download/FileDownloadRequestTest.java
+++ b/extension-clients/file-extension-client/src/test/java/io/sterodium/extensions/client/download/FileDownloadRequestTest.java
@@ -23,6 +23,7 @@ import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
+import java.util.Base64;
 
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.is;
@@ -56,7 +57,7 @@ public class FileDownloadRequestTest extends BaseRequestTest {
         StubServlet stubServlet = new StubServlet();
         stubServlet.setFunction(responseHandleFunction);
 
-        fileToGet = File.createTempFile("test", ".txt");
+        fileToGet = File.createTempFile("test filename with spaces", ".txt");
         FileUtils.write(fileToGet, EXPECTED_CONTENT, StandardCharsets.UTF_8);
 
         extensionPath = String.format(PATH, HubRequestsProxyingServlet.class.getSimpleName(), SESSION_ID, FileDownloadServlet.class.getSimpleName(), "*");
@@ -99,7 +100,9 @@ public class FileDownloadRequestTest extends BaseRequestTest {
                 HttpServletRequest req = (HttpServletRequest) invocationOnMock.getArguments()[0];
                 HttpServletResponse resp = (HttpServletResponse) invocationOnMock.getArguments()[1];
 
-                String pathInfo = req.getPathInfo();
+                String pathInfo = req.getRequestURI().substring(req.getServletPath().length() + 1);
+                pathInfo = new String(Base64.getUrlDecoder().decode(pathInfo.getBytes()));
+
                 assertThat(pathInfo, containsString(fileToGet.getAbsolutePath()));
 
                 try (

--- a/node-extensions/file-extension/src/main/java/io/sterodium/extensions/node/delete/FileDeleteServlet.java
+++ b/node-extensions/file-extension/src/main/java/io/sterodium/extensions/node/delete/FileDeleteServlet.java
@@ -2,6 +2,7 @@ package io.sterodium.extensions.node.delete;
 
 import java.io.File;
 import java.io.IOException;
+import java.util.Base64;
 import java.util.logging.Logger;
 import javax.servlet.ServletException;
 import javax.servlet.http.HttpServlet;
@@ -20,7 +21,8 @@ public class FileDeleteServlet extends HttpServlet {
 
     @Override
     protected void doGet(HttpServletRequest req, HttpServletResponse resp) throws ServletException, IOException {
-        String pathInfo = req.getPathInfo();
+        String pathInfo = req.getRequestURI().substring(req.getServletPath().length() + 1);
+        pathInfo = new String(Base64.getUrlDecoder().decode(pathInfo.getBytes()));
         LOGGER.info("Request for file delete received with path: " + pathInfo);
 
         File file = new File(pathInfo);

--- a/node-extensions/file-extension/src/main/java/io/sterodium/extensions/node/download/FileDownloadServlet.java
+++ b/node-extensions/file-extension/src/main/java/io/sterodium/extensions/node/download/FileDownloadServlet.java
@@ -13,6 +13,7 @@ import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.nio.file.Files;
+import java.util.Base64;
 import java.util.logging.Logger;
 
 /**
@@ -27,7 +28,8 @@ public class FileDownloadServlet extends HttpServlet {
 
     @Override
     protected void doGet(HttpServletRequest req, HttpServletResponse resp) throws ServletException, IOException {
-        String pathInfo = req.getPathInfo();
+        String pathInfo = req.getRequestURI().substring(req.getServletPath().length() + 1);
+        pathInfo = new String(Base64.getUrlDecoder().decode(pathInfo.getBytes()));
         LOGGER.info("Request for file download received with path: " + pathInfo);
 
         File file = new File(pathInfo);

--- a/node-extensions/file-extension/src/test/java/io/sterodium/extensions/node/delete/FileDeleteServletTest.java
+++ b/node-extensions/file-extension/src/test/java/io/sterodium/extensions/node/delete/FileDeleteServletTest.java
@@ -17,6 +17,7 @@ import java.io.File;
 import java.io.IOException;
 import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
+import java.util.Base64;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -48,7 +49,7 @@ public class FileDeleteServletTest extends BaseServletTest {
 
         CloseableHttpClient httpClient = HttpClients.createDefault();
 
-        String encode = URLEncoder.encode(fileTobeDeleted.getAbsolutePath(), "UTF-8");
+        String encode = Base64.getUrlEncoder().encodeToString(fileTobeDeleted.getAbsolutePath().getBytes(StandardCharsets.UTF_8));
         HttpGet httpGet = new HttpGet("/FileDeleteServlet/" + encode);
 
         CloseableHttpResponse execute = httpClient.execute(serverHost, httpGet);

--- a/node-extensions/file-extension/src/test/java/io/sterodium/extensions/node/download/FileDownloadServletTest.java
+++ b/node-extensions/file-extension/src/test/java/io/sterodium/extensions/node/download/FileDownloadServletTest.java
@@ -21,8 +21,8 @@ import org.seleniumhq.jetty9.server.Server;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
-import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
+import java.util.Base64;
 
 import static junit.framework.TestCase.assertTrue;
 import static org.hamcrest.CoreMatchers.containsString;
@@ -51,12 +51,12 @@ public class FileDownloadServletTest extends BaseServletTest {
 
     @Test
     public void getShouldReturnFileContentsWithNameInHeader() throws IOException {
-        File fileToGet = File.createTempFile("test", ".txt");
+        File fileToGet = File.createTempFile("test filename with spaces", ".txt");
         FileUtils.write(fileToGet, "expected_content", StandardCharsets.UTF_8);
 
         CloseableHttpClient httpClient = HttpClients.createDefault();
 
-        String encode = URLEncoder.encode(fileToGet.getAbsolutePath(), "UTF-8");
+        String encode = Base64.getUrlEncoder().encodeToString(fileToGet.getAbsolutePath().getBytes(StandardCharsets.UTF_8));
         HttpGet httpGet = new HttpGet("/FileDownloadServlet/" + encode);
 
         CloseableHttpResponse execute = httpClient.execute(serverHost, httpGet);
@@ -79,7 +79,7 @@ public class FileDownloadServletTest extends BaseServletTest {
     public void getShouldReturnBadRequestWhenFileNotExists() throws IOException {
         CloseableHttpClient httpClient = HttpClients.createDefault();
 
-        String encode = URLEncoder.encode("/some/location/", "UTF-8");
+        String encode = Base64.getUrlEncoder().encodeToString("/some/location/".getBytes(StandardCharsets.UTF_8));
         HttpGet httpGet = new HttpGet("/FileDownloadServlet/" + encode);
 
         CloseableHttpResponse execute = httpClient.execute(serverHost, httpGet);
@@ -100,7 +100,7 @@ public class FileDownloadServletTest extends BaseServletTest {
         File directory = Files.createTempDir();
         CloseableHttpClient httpClient = HttpClients.createDefault();
 
-        String encode = URLEncoder.encode(directory.getAbsolutePath(), "UTF-8");
+        String encode = Base64.getUrlEncoder().encodeToString(directory.getAbsolutePath().getBytes(StandardCharsets.UTF_8));
         HttpGet httpGet = new HttpGet("/FileDownloadServlet/" + encode);
 
         CloseableHttpResponse execute = httpClient.execute(serverHost, httpGet);

--- a/pom.xml
+++ b/pom.xml
@@ -423,7 +423,7 @@
                                 <configuration>
                                     <signature>
                                         <groupId>org.codehaus.mojo.signature</groupId>
-                                        <artifactId>java17</artifactId>
+                                        <artifactId>java18</artifactId>
                                         <version>1.0</version>
                                     </signature>
                                 </configuration>


### PR DESCRIPTION
Base64 URL encoding/decoding added to servlet-request pairs:
- FileDeleteServlet/FileDeleteRequest
- FileDownloadServlet/FileDownloadRequest

Java version moved from 1.7 to 1.8